### PR TITLE
incldue a space after | in title

### DIFF
--- a/layouts/partials/sections/common/head.html
+++ b/layouts/partials/sections/common/head.html
@@ -9,7 +9,7 @@
   {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
   <title>
     {{ block "title" . }}
-      {{ with .Title }}{{ . }} |{{ end }}{{ .Site.Title }}
+      {{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}
     {{ end }}
   </title>
 


### PR DESCRIPTION
e.g. `Asset minification |Hugo` becomes `Asset minification | Hugo`