### PR TITLE
Make content text color black, font weight normal back to 400

### DIFF
--- a/layouts/partials/sections/common/head.html
+++ b/layouts/partials/sections/common/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8" />
   {{/* TODO1 self host https://fonts.google.com/specimen/Mulish?preview.text_type=custom */}}
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,300;0,500;0,700;1,500;1,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
   <title>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -100,7 +100,7 @@ module.exports = {
 		},
 		fontWeight: {
 			light: 300,
-			normal: 500,
+			normal: 400,
 			semibold: 600,
 			bold: 700,
 			
@@ -116,6 +116,7 @@ module.exports = {
 						maxWidth: '80ch',
 						fontWeight: '400',
 						lineHeight: '1.5',
+						color: '#000',
 						strong: {
 							fontWeight: '600',
 						},


### PR DESCRIPTION
I think we should strive for maximum contrast on the guides: black on white, also with that I found it best to go back to a regular font weight (400) for the body text, which is what we also have in the other site, I think.

What do you think @coliff ?